### PR TITLE
Fix Keycloak throwing exception for Secret Key if we are using public…

### DIFF
--- a/src/AspNet.Security.OAuth.Keycloak/KeycloakAuthenticationAccessType.cs
+++ b/src/AspNet.Security.OAuth.Keycloak/KeycloakAuthenticationAccessType.cs
@@ -1,0 +1,13 @@
+﻿// Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+// See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers
+// for more information concerning the license and the contributors participating to this project.
+
+namespace AspNet.Security.OAuth.Keycloak
+{
+    public enum KeycloakAuthenticationAccessType
+    {
+        Confidential,
+        Public,
+        BearerOnly
+    }
+}


### PR DESCRIPTION
… access type.

I added a new property for Keycloak's access type, we'll swallow the exception thrown for missing Secret Key if we are using a public access type. Everything else stays the same.